### PR TITLE
Add Conan and CMake configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,24 @@
 
 # debug information files
 *.dwo
+
+# CMake
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+CMakeUserPresets.json
+
+# Conan and CMake build directories
+build/
+out/
+
+# Visual Studio local config
+.vs/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.10)
+project(PuttIt)
+
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+find_package(SDL2 REQUIRED)
+find_package(GTest REQUIRED)
+
+add_subdirectory(code/tests)

--- a/code/tests/CMakeLists.txt
+++ b/code/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+project(PuttIt-Tests)
+
+add_executable(${PROJECT_NAME})
+
+set(SRCS main.cpp SDLTests.cpp)
+set(HDRS )
+
+target_include_directories(${PROJECT_NAME} PRIVATE ${HDRS})
+target_link_libraries(${PROJECT_NAME} PRIVATE SDL2::SDL2 gtest::gtest)
+target_sources(${PROJECT_NAME} PRIVATE ${SRCS})

--- a/code/tests/SDLTests.cpp
+++ b/code/tests/SDLTests.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+#include <SDL2/SDL.h>
+
+TEST(SLDTests, SDL_Init) {
+	ASSERT_NO_THROW(SDL_Init(SDL_INIT_EVERYTHING));
+}

--- a/code/tests/main.cpp
+++ b/code/tests/main.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+	testing::InitGoogleTest(&argc, argv);
+	return RUN_ALL_TESTS();
+}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,26 @@
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout, CMakeToolchain, CMakeDeps
+
+class GameConan(ConanFile):
+    name = "putt-it"
+    settings = "os", "arch", "compiler", "build_type"
+
+    def generate(self):
+        tc = CMakeToolchain(self)
+        tc.generator="Ninja"
+        tc.generate()
+
+        deps = CMakeDeps(self)
+        deps.generate()
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires("sdl/2.32.10")
+        self.requires("gtest/1.17.0")
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()


### PR DESCRIPTION
## Description
- Project requirements easy import : `conan install . -s build_type=X --build=missing`
- CMake architecture with possibility to build multiple executables and libraries
- Ignoring Conan and CMake generated files, and compiled and linked files
- Test of the whole configuration with a gtest executable using SDL library
- Currently requiring SDL2 and GTest
- Uses CMakeUserPresets.json, generated by Conan, as the list of presets
## Issues
Fixes #1