### PR TITLE
CI for Windows based unit-test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,10 @@ name: tests
 
 on: push
 
-# on:
-#   pull_request:
-#     branches:
-#       - main
+on:
+  pull_request:
+    branches:
+      - main
 
 jobs:
   test-windows:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,9 +30,8 @@ jobs:
         run: cmake --preset conan-release
 
       - name: Build
-        run: cmake --build build/Release
+        run: cmake --build --preset conan-release
 
       - name: Run tests
         run: |
-          cd build/Release
-          ctest --output-on-failure
+          ctest --preset conan-release --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,5 @@
 name: tests
 
-on: push
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,16 +13,25 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Setup MSVC
+        uses: ilammy/msvc-dev-cmd@v1
+
       - name: Install Conan
         run: pip install conan
+
       - name: Conan profile detect
         run: conan profile detect
+
       - name: Conan install
         run: conan install . --build=missing --settings build_type=Release --settings compiler.cppstd=17
+
       - name: Configure
         run: cmake --preset conan-release
+
       - name: Build
         run: cmake --build build/Release
+
       - name: Run tests
         run: |
           cd build/Release

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: tests
+
+on: push
+
+# on:
+#   pull_request:
+#     branches:
+#       - main
+
+jobs:
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Conan
+        run: pip install conan
+      - name: Conan profile detect
+        run: conan profile detect
+      - name: Conan install
+        run: conan install . --build=missing --settings build_type=Release
+      - name: Configure
+        run: cmake --preset conan-release
+      - name: Build
+        run: cmake --build build/Release
+      - name: Run tests
+        run: |
+          cd build/Release
+          ctest --output-on-failure

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Conan profile detect
         run: conan profile detect
       - name: Conan install
-        run: conan install . --build=missing --settings build_type=Release
+        run: conan install . --build=missing --settings build_type=Release --settings compiler.cppstd=17
       - name: Configure
         run: cmake --preset conan-release
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(PuttIt)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+include(CTest)
+
 find_package(SDL2 REQUIRED)
 find_package(GTest REQUIRED)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.10)
 project(PuttIt)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CTest)
 

--- a/code/tests/CMakeLists.txt
+++ b/code/tests/CMakeLists.txt
@@ -2,6 +2,11 @@ project(PuttIt-Tests)
 
 add_executable(${PROJECT_NAME})
 
+add_test(
+	NAME ${PROJECT_NAME}
+	COMMAND $<TARGET_FILE:${PROJECT_NAME}>
+)
+
 set(SRCS main.cpp SDLTests.cpp)
 set(HDRS )
 


### PR DESCRIPTION
## Description
- CI test job is now executed on a GitHub windows runner whenever a branch is trying to be merged to the main
- The main branch is protected by the tests job check status, the tests have to be a success to accept a push on the branch (even for admin contributors)

## Issues
Fixes #2 